### PR TITLE
Apply sumi-e visual philosophy

### DIFF
--- a/front-end/core/router.js
+++ b/front-end/core/router.js
@@ -49,8 +49,11 @@ class Router {
         if (text.includes('hidden')) return TABS.HIDDEN;
         return null;
     }
-    
+
     async switchTab(tabName) {
+        const overlay = document.createElement('div');
+        overlay.className = 'tab-transition';
+        document.body.appendChild(overlay);
         console.log(`[DEBUG] ========== SWITCHING TO TAB: ${tabName} ==========`);
         
         // Log state before switching
@@ -95,9 +98,11 @@ class Router {
         
         // Handle tab-specific logic
         await this.handleTabSwitch(tabName);
-        
+
         this.currentTab = tabName;
         console.log(`[DEBUG] ========== TAB SWITCH COMPLETE ==========`);
+
+        setTimeout(() => overlay.remove(), 300);
     }
     
     async handleTabSwitch(tabName) {

--- a/front-end/features/auth/auth.css
+++ b/front-end/features/auth/auth.css
@@ -56,13 +56,13 @@
 
 .modal input:focus {
     outline: none;
-    border-color: #695b8d;
+    border-color: var(--ink-black);
 }
 
 .modal button {
     width: 100%;
     padding: 12px;
-    background: #695b8d;
+    background: var(--ink-black);
     color: white;
     border: none;
     border-radius: 4px;
@@ -75,7 +75,7 @@
 }
 
 .modal button:hover {
-    background: #574a75;
+    background: var(--ink-wash-5);
 }
 
 .auth-switch {
@@ -86,7 +86,7 @@
 }
 
 .auth-switch a {
-    color: #695b8d;
+    color: var(--ink-black);
     text-decoration: none;
     font-weight: 500;
 }
@@ -124,7 +124,7 @@
 
 .user-info button {
     padding: 6px 12px;
-    background: #695b8d;
+    background: var(--ink-black);
     color: white;
     border: none;
     border-radius: 4px;
@@ -134,5 +134,5 @@
 }
 
 .user-info button:hover {
-    background: #574a75;
+    background: var(--ink-wash-5);
 }

--- a/front-end/features/favorites/FavoritesManager.js
+++ b/front-end/features/favorites/FavoritesManager.js
@@ -101,8 +101,8 @@ class FavoritesManager {
                     card.remove();
                     // Check if no favorites left
                     if (document.querySelectorAll('.favorite-card').length === 0) {
-                        document.querySelector('.favorites-container').innerHTML = 
-                            '<div style="padding:40px; text-align:center; color:#999;">No favorites yet</div>';
+                        document.querySelector('.favorites-container').innerHTML =
+                            '<div style="padding:40px; text-align:center; color:#999;">静寂 • Emptiness awaits your choices</div>';
                     }
                 }, 300);
             }
@@ -152,7 +152,7 @@ class FavoritesManager {
                 const userFavorites = await this.api.loadUserFavorites(this.state.currentUser.email);
                 
                 if (userFavorites.length === 0) {
-                    favoritesList.innerHTML = '<div class="favorites-empty">No favorites yet. Click the ♡ on properties to add them here.</div>';
+                    favoritesList.innerHTML = '<div class="favorites-empty">静寂 • Emptiness awaits your choices</div>';
                     return;
                 }
                 
@@ -194,7 +194,7 @@ class FavoritesManager {
             const favoriteProperties = this.state.getFavoriteProperties();
             
             if (favoriteProperties.length === 0) {
-                favoritesList.innerHTML = '<div class="favorites-empty">No favorites yet. Click the ♡ on properties to add them here.</div>';
+                favoritesList.innerHTML = '<div class="favorites-empty">静寂 • Emptiness awaits your choices</div>';
                 return;
             }
             

--- a/front-end/features/favorites/favorites.css
+++ b/front-end/features/favorites/favorites.css
@@ -13,16 +13,16 @@
 .favorite-card {
     display: flex;
     align-items: center;
-    background: white;
+    background: linear-gradient(135deg, var(--rice-paper) 0%, rgba(253,252,248,0.7) 100%);
     border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    border: 1px solid rgba(26,26,26,0.08);
+    box-shadow: none;
     padding: 16px;
     transition: all 0.3s ease;
     position: relative;
 }
 
 .favorite-card:hover {
-    box-shadow: 0 4px 16px rgba(0,0,0,0.15);
     transform: translateY(-2px);
 }
 
@@ -73,23 +73,24 @@
 
 .favorite-ward {
     font-weight: 600;
-    color: #333;
+    color: var(--ink-black);
     font-size: 16px;
 }
 
 .favorite-price {
     font-size: 18px;
     font-weight: bold;
-    color: #695b8d;
+    color: var(--ink-black);
+    animation: subtle-pulse 4s ease-in-out infinite;
 }
 
 .favorite-size {
-    color: #666;
+    color: var(--ink-wash-5);
     font-size: 14px;
 }
 
 .favorite-location {
-    color: #666666;
+    color: var(--ink-wash-5);
     margin-bottom: 4px;
 }
 
@@ -99,27 +100,24 @@
 }
 
 .processing-status {
-    padding: 6px 12px;
-    border-radius: 20px;
+    padding: 0;
     font-size: 12px;
     font-weight: 500;
+    background: none;
+    color: var(--ink-black);
+    opacity: 0.7;
 }
 
-.processing-status.processing {
-    background: #fff4e5;
-    color: #b26a00;
+.processing-status::before {
+    content: '○';
 }
 
-.processing-status.processed {
-    background: #e6f4ea;
-    color: #2e7d32;
-    cursor: pointer;
-    text-decoration: underline;
+.processing-status.processed::before {
+    content: '●';
 }
 
-.processing-status.failed {
-    background: #fdecea;
-    color: #c62828;
+.processing-status.failed::before {
+    content: '×';
 }
 
 .remove-favorite-btn {
@@ -194,4 +192,17 @@
 
 .favorite-details {
     padding: 15px;
+}
+
+@keyframes subtle-pulse {
+    0%, 100% { opacity: 0.9; }
+    50% { opacity: 1; }
+}
+
+@media (max-width: 768px) {
+    .favorite-card {
+        border-left: none;
+        border-right: none;
+        border-radius: 0;
+    }
 }

--- a/front-end/features/hidden/hidden.css
+++ b/front-end/features/hidden/hidden.css
@@ -34,7 +34,7 @@
 }
 
 .fav-list li a:hover {
-    color: #695b8d;
+    color: var(--ink-black);
 }
 
 .fav-list .remove-btn {

--- a/front-end/main.js
+++ b/front-end/main.js
@@ -6,6 +6,11 @@
 // Initialize app
 document.addEventListener('DOMContentLoaded', async function() {
     console.log('[DEBUG] Initializing Tokyo Real Estate App...');
+
+    window.addEventListener('scroll', () => {
+        const scrolled = window.pageYOffset;
+        document.body.style.setProperty('--fuji-offset', `${scrolled * 0.3}px`);
+    });
     
     // Create instances
     const api = new PropertyAPI(API_URL, FAVORITES_API_URL);

--- a/front-end/shared/styles/base.css
+++ b/front-end/shared/styles/base.css
@@ -5,16 +5,27 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Zen+Kaku+Gothic+Antique:wght@400;700&family=Noto+Sans+JP:wght@400;700&display=swap');
 
+:root {
+    --ink-black: #1a1a1a;
+    --rice-paper: #fdfcf8;
+    --ink-wash-1: rgba(26,26,26,0.05);
+    --ink-wash-2: rgba(26,26,26,0.15);
+    --ink-wash-3: rgba(26,26,26,0.35);
+    --ink-wash-5: rgba(26,26,26,0.65);
+    --red-seal: #b8312f;
+}
+
 * {
     box-sizing: border-box;
     margin: 0;
     padding: 0;
+    transition: opacity 0.3s ease, transform 0.3s ease, background-color 0.3s ease;
 }
 
 body {
     font-family: 'Noto Sans JP', 'Hiragino Sans', -apple-system, BlinkMacSystemFont, sans-serif;
-    background: #F7F5F2;
-    color: #222222;
+    background: var(--rice-paper);
+    color: var(--ink-black);
     line-height: 1.7;
     font-size: 15px;
     overflow-x: hidden;
@@ -30,12 +41,13 @@ body::before {
     right: 0;
     width: 600px;
     height: 400px;
-    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400"><path d="M300 100 L200 300 L400 300 Z" fill="%23e8e4e0" opacity="0.06"/><path d="M300 100 L250 200 L350 200 Z" fill="%23ffffff" opacity="0.08"/></svg>');
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400"><path d="M300 120 Q280 250 200 350 L400 350 Q320 250 300 120" fill="none" stroke="%23000000" stroke-width="0.5" opacity="0.03" stroke-linecap="round"/><path d="M300 120 Q290 180 280 200 L320 200 Q310 180 300 120" fill="%23ffffff" opacity="0.06"/></svg>');
     background-repeat: no-repeat;
     background-position: top right;
     background-size: contain;
     pointer-events: none;
     z-index: 0;
+    transform: translateY(var(--fuji-offset, 0px));
 }
 
 @keyframes fadeInUp {
@@ -68,4 +80,48 @@ body::before {
     100% {
         opacity: 1;
     }
+}
+
+@keyframes ink-spread {
+    0% {
+        opacity: 0;
+        transform: scale(0.8);
+        filter: blur(3px);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+        filter: blur(0);
+    }
+}
+
+@keyframes ink-drop {
+    0% {
+        opacity: 0;
+        transform: scale(0.95);
+    }
+    100% {
+        opacity: 1;
+        transform: scale(1);
+    }
+}
+
+@keyframes fade-through {
+    0% { opacity: 0; }
+    50% { opacity: 1; }
+    100% { opacity: 0; }
+}
+
+.tab-transition {
+    position: fixed;
+    inset: 0;
+    background: var(--rice-paper);
+    animation: fade-through 0.3s ease forwards;
+    pointer-events: none;
+    z-index: 9999;
+}
+
+*:focus {
+    outline: 1px solid rgba(26,26,26,0.2);
+    outline-offset: 4px;
 }

--- a/front-end/shared/styles/components.css
+++ b/front-end/shared/styles/components.css
@@ -13,7 +13,7 @@ table {
 }
 
 th {
-    background: #f1eee8;
+    background: var(--ink-wash-1);
     padding: 0;
     position: sticky;
     top: 0;
@@ -23,15 +23,15 @@ th {
     text-align: center;
     text-transform: uppercase;
     letter-spacing: 0.1em;
-    color: #333333;
-    border-bottom: 1px solid #cccccc;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
+    color: var(--ink-black);
+    border: none;
+    border-bottom: 1px solid var(--ink-wash-2);
 }
 
 thead th {
     position: sticky;
     top: 0;
-    background: #f1eee8;
+    background: var(--ink-wash-1);
     z-index: 20;
 }
 
@@ -51,7 +51,7 @@ th.sortable {
 }
 
 .column-header:hover {
-    background: rgba(105, 91, 141, 0.05);
+    background: var(--ink-wash-1);
 }
 
 .sort-arrows {
@@ -62,29 +62,22 @@ th.sortable {
 }
 
 .sort-arrows.active {
-    color: #695b8d;
+    color: var(--ink-black);
     font-weight: 700;
 }
 
 td {
-    border-bottom: 1px solid #f0f0f0;
+    border: none;
+    border-bottom: 1px solid var(--ink-wash-1);
     padding: 14px 16px;
     font-size: 14px;
     vertical-align: middle;
-    color: #333333;
+    color: var(--ink-black);
     font-family: 'Noto Sans JP', sans-serif;
     font-weight: 400;
     position: relative;
     word-break: break-word;
-}
-
-/* Zebra striping */
-tbody tr:nth-child(odd) td {
-    background: #ffffff;
-}
-
-tbody tr:nth-child(even) td {
-    background: #fafaf8;
+    background: transparent;
 }
 
 tbody tr {
@@ -105,9 +98,18 @@ tbody tr td:last-child {
 
 /* Hover state */
 tbody tr:hover td {
-    background: #f3f0f8 !important;
-    transform: translateY(-1px) scale(1.002);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+    background: transparent;
+    position: relative;
+}
+
+tbody tr:hover td::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 1px;
+    background: linear-gradient(90deg, transparent 0%, rgba(26,26,26,0.3) 50%, transparent 100%);
 }
 
 /* Clickable row */
@@ -175,51 +177,48 @@ tbody tr.no-link {
 
 /* Verdict Badges */
 .verdict {
-    padding: 6px 12px;
-    border-radius: 4px;
-    font-size: 11px;
+    border-radius: 50%;
+    width: 48px;
+    height: 48px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1.5px solid currentColor;
+    background: transparent;
+    font-size: 9px;
+    padding: 0;
     font-weight: 600;
     text-transform: uppercase;
     text-align: center;
     letter-spacing: 0.1em;
     transition: all 120ms ease;
     font-family: 'Noto Sans JP', sans-serif;
-    position: relative;
-    border: 1px solid transparent;
 }
 
 .verdict-buy, .verdict-strong_buy, .verdict-buy_candidate {
-    background: #e6f4ea;
-    color: #2e7d32;
-    border-color: #2e7d32;
+    color: var(--red-seal);
+    border-color: var(--red-seal);
 }
 
 .verdict-hold, .verdict-watch {
-    background: #fff4e5;
-    color: #b26a00;
-    border-color: #b26a00;
+    color: var(--ink-black);
+    opacity: 0.7;
 }
 
 .verdict-pass, .verdict-reject {
-    background: #fdecea;
-    color: #c62828;
-    border-color: #c62828;
-}
-
-.verdict:hover {
-    transform: scale(1.02);
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    color: var(--ink-black);
+    opacity: 0.7;
 }
 
 /* Buttons */
 .link-button {
-    color: #333333;
+    color: var(--ink-black);
     text-decoration: none;
     font-weight: 400;
     font-size: 12px;
     font-family: 'Noto Sans JP', sans-serif;
     padding: 6px 12px;
-    border: 1px solid #cccccc;
+    border: 1px solid var(--ink-wash-2);
     border-radius: 4px;
     background: transparent;
     transition: all 120ms ease;
@@ -227,9 +226,8 @@ tbody tr.no-link {
 }
 
 .link-button:hover {
-    background: #f3f0f8;
-    border-color: #695b8d;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    background: var(--ink-wash-1);
+    border-color: var(--ink-black);
 }
 
 /* Tab Button */
@@ -243,19 +241,31 @@ tbody tr.no-link {
     font-family: 'Noto Sans JP', sans-serif;
     font-size: 14px;
     transition: all 120ms ease;
+    border-bottom: none;
 }
 
 .tab-button.active {
-    color: #695b8d;
-    border-bottom: 3px solid #695b8d;
+    color: var(--ink-black);
+}
+
+.tab-button.active::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 20%;
+    right: 20%;
+    height: 2px;
+    background: var(--ink-black);
+    opacity: 0.4;
+    border-radius: 1px;
 }
 
 .tab-button:hover {
-    color: #695b8d;
+    color: var(--ink-black);
 }
 
 .favorites-count {
-    background: #e91e63;
+    background: var(--red-seal);
     color: white;
     border-radius: 10px;
     padding: 2px 6px;
@@ -270,16 +280,18 @@ tbody tr.no-link {
     cursor: pointer;
     font-size: 20px;
     padding: 4px 8px;
-    transition: all 0.2s;
-    color: #cccccc;
+    font-weight: 100;
+    transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+    color: var(--ink-wash-3);
 }
 
 .heart-btn.favorited {
-    color: #e91e63;
+    color: var(--red-seal);
 }
 
-.heart-btn:hover {
-    transform: scale(1.1);
+.heart-btn:not(.favorited):hover {
+    transform: scale(1.05);
+    opacity: 0.6;
 }
 
 .heart-btn:disabled {
@@ -309,14 +321,23 @@ tbody tr.no-link {
     cursor: not-allowed;
 }
 
+/* Filter Dropdown */
+.filter-dropdown-content {
+    border-radius: 0;
+    border: 1px solid rgba(26,26,26,0.1);
+    box-shadow: none;
+    animation: ink-drop 0.3s ease;
+    background: var(--rice-paper);
+}
+
 /* Loading Skeleton */
 .loading {
-    background: #ffffff;
+    background: var(--rice-paper);
     border-radius: 8px;
-    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
     overflow: hidden;
     position: relative;
     padding: 24px;
+    animation: ink-spread 0.6s ease-out forwards;
 }
 
 .loading::before {
@@ -324,35 +345,23 @@ tbody tr.no-link {
     position: absolute;
     top: 20px;
     left: 24px;
-    color: #999999;
+    color: var(--ink-wash-5);
     font-size: 13px;
     font-family: 'Noto Sans JP', sans-serif;
-}
-
-.skeleton {
-    animation: skeleton-loading 1.5s infinite ease-in-out;
 }
 
 .skeleton-row {
     display: flex;
     padding: 14px 16px;
-    border-bottom: 1px solid #f0f0f0;
+    border-bottom: 1px solid var(--ink-wash-1);
     margin-top: 40px;
 }
 
 .skeleton-cell {
     height: 20px;
-    background: linear-gradient(90deg, 
-        #f5f5f5 0%, 
-        #eeeeee 25%, 
-        #f5f5f5 50%, 
-        #eeeeee 75%,
-        #f5f5f5 100%
-    );
-    background-size: 200% 100%;
+    background: var(--ink-wash-1);
     border-radius: 4px;
     margin-right: 12px;
-    position: relative;
 }
 
 .skeleton-cell:last-child {
@@ -368,15 +377,6 @@ tbody tr.no-link {
 .skeleton-cell.age { width: 100px; }
 .skeleton-cell.light { width: 100px; }
 .skeleton-cell.verdict { width: 80px; }
-
-@keyframes skeleton-loading {
-    0% { 
-        background-position: -200% 0;
-    }
-    100% { 
-        background-position: 200% 0;
-    }
-}
 
 /* Error Banner */
 .error-banner {

--- a/front-end/shared/styles/layout.css
+++ b/front-end/shared/styles/layout.css
@@ -3,6 +3,7 @@
  * Container, grid, spacing, and layout-related styles
  */
 
+
 .container {
     max-width: none;
     width: 100%;
@@ -17,15 +18,17 @@
 }
 
 h1 {
-    color: #222222;
+    color: var(--ink-black);
     margin-bottom: 40px;
     font-size: 48px;
-    font-weight: 700;
+    font-weight: 300;
     text-align: center;
     font-family: 'Zen Kaku Gothic Antique', serif;
-    letter-spacing: 0.15em;
+    letter-spacing: 0.3em;
     position: relative;
     padding-bottom: 20px;
+    opacity: 0.85;
+    text-shadow: 2px 2px 4px rgba(0,0,0,0.05);
 }
 
 /* Brushstroke underline */
@@ -37,8 +40,9 @@ h1::after {
     transform: translateX(-50%);
     width: 120px;
     height: 3px;
-    background: linear-gradient(90deg, transparent 0%, #695b8d 20%, #695b8d 80%, transparent 100%);
+    background: linear-gradient(90deg, transparent 0%, var(--ink-black) 50%, transparent 100%);
     border-radius: 2px;
+    opacity: 0.4;
 }
 
 .results-info {
@@ -89,9 +93,10 @@ h1::after {
 /* Mobile responsiveness */
 @media (max-width: 768px) {
     .container {
-        padding: 20px 9px;
+        padding: 20px 0;
+        border-radius: 0;
     }
-    
+
     h1 {
         font-size: 32px;
         margin-bottom: 30px;


### PR DESCRIPTION
## Summary
- Introduce a sumi-e inspired palette with brushstroke Mt. Fuji background and parallax scroll effect.
- Simplify tables, tabs, and interactive elements with subtle ink-wash transitions and seal-style verdict badges.
- Rework favorites UI with minimalist cards, breathing price animation, symbolic status indicators, and poetic empty-state message.

## Testing
- `pytest` *(fails: ImportError in tests/test_overview_parser.py: cannot import name 'parse_overview_section')*


------
https://chatgpt.com/codex/tasks/task_e_68944c318ed4832f88a801d66b239b72